### PR TITLE
webdev: Add link to Jetzig project

### DIFF
--- a/content/webdev/index.md
+++ b/content/webdev/index.md
@@ -24,6 +24,8 @@ looking under the hood of modern web development.
    A I/O agnostic HTTP/1.1 parser and encoder for Zig
 - [haze/zelda](https://github.com/haze/zelda)
    async aware, Zig native http client, using zig-libressl and hzzp
+- [jetzig-framework/jetzig](https://github.com/jetzig-framework/jetzig)
+   Web framework and templating language written in 100% Zig
    
 ## TLS
 


### PR DESCRIPTION
Jetzig web framework/templating language

https://jetzig.dev/